### PR TITLE
Potential fix for code scanning alert no. 82: Code injection

### DIFF
--- a/buggy_python_code.py
+++ b/buggy_python_code.py
@@ -22,8 +22,16 @@ def print_nametag(format_string, person):
 
 
 def fetch_website(urllib_version, url):
-    # Import the requested version (2 or 3) of urllib
-    exec(f"import urllib{urllib_version} as urllib", globals())
+    # Map valid versions to their corresponding modules
+    urllib_modules = {
+        "2": "urllib2",
+        "3": "urllib3"
+    }
+    # Validate and import the requested version of urllib
+    if urllib_version in urllib_modules:
+        urllib = __import__(urllib_modules[urllib_version])
+    else:
+        raise ValueError("Invalid urllib version specified")
     # Fetch and print the requested URL
 
     try:


### PR DESCRIPTION
Potential fix for [https://github.com/SamuelH212/PV080_buggy_code/security/code-scanning/82](https://github.com/SamuelH212/PV080_buggy_code/security/code-scanning/82)

To fix the issue, we should avoid using `exec` to dynamically import modules. Instead, we can use a safer approach by explicitly mapping user input to allowed module names. This ensures that only predefined, safe versions of `urllib` can be imported, and any invalid or malicious input is rejected.

Steps to fix:
1. Replace the `exec` statement with a dictionary that maps valid `urllib_version` values (e.g., "2" or "3") to the corresponding modules (`urllib2` or `urllib3`).
2. Validate the user input against this dictionary and raise an error for invalid input.
3. Import the selected module using the dictionary lookup instead of `exec`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
